### PR TITLE
Version 1.2.0 → 1.2.1

### DIFF
--- a/mvc-updates.cabal
+++ b/mvc-updates.cabal
@@ -1,5 +1,5 @@
 Name: mvc-updates
-Version: 1.2.0
+Version: 1.2.1
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 License: BSD3


### PR DESCRIPTION
There are no code changes in this version but we need a new version in order to upload to Hackage because the version on Hackage contains a code change that did not match this repository.  Specifically, version 1.2.0 on Hackage is missing this commit:

https://github.com/Gabriella439/Haskell-MVC-Updates-Library/commit/47b31202b761439947ffbc89ec1c6854c1520819

… so it won't build against newer versions of `foldl`.  By uploading a new (latest, correct) version of this package that should hopefully fix this.